### PR TITLE
error on a plugin when deployed - tried to correct it

### DIFF
--- a/pelican-plugins/liquid_tags/test_data/content/test-generic-config-tag.md
+++ b/pelican-plugins/liquid_tags/test_data/content/test-generic-config-tag.md
@@ -2,6 +2,6 @@ Title: test generic config tag
 Date: 2017-12-03
 Authors: A. Person
 
-This post is written by 
+<!-- This post is written by 
 {% generic config author %}
-if all goes well the blog post author (from settings, not from the post) shows up one line above
+if all goes well the blog post author (from settings, not from the post) shows up one line above -->


### PR DESCRIPTION
the liqui_tag plugin which is not allowed contains an error.